### PR TITLE
[feat] 解除 app 和 performance 的循环引用问题

### DIFF
--- a/packages/core/src/application/app-controller/interface.ts
+++ b/packages/core/src/application/app-controller/interface.ts
@@ -1,0 +1,16 @@
+import { createServiceSymbol } from '../../utils';
+import { AppOptions, IApp } from '../app/service';
+
+export const IAppControllerKey = createServiceSymbol('IAppController');
+
+export interface IAppController {
+  /**
+   * 注册应用
+   */
+  registerApp: (options: AppOptions) => IApp;
+
+  /**
+   * 获取已经注册的应用
+   */
+  getApp: (name: string) => IApp;
+}

--- a/packages/core/src/application/app-controller/service.spec.ts
+++ b/packages/core/src/application/app-controller/service.spec.ts
@@ -3,7 +3,7 @@ import { Container } from 'inversify';
 import { StatusEnum } from '../../constants/status';
 import { buildProviderModule } from '../../provider';
 import { AppHooks, AppOptions, IApp } from '../app/service';
-import { IAppService, IAppServiceKey } from './service';
+import { IAppController, IAppControllerKey } from './service';
 
 async function delay(time: number): Promise<void> {
   return new Promise((resolve) => {
@@ -14,8 +14,8 @@ async function delay(time: number): Promise<void> {
 function getAppInstance(options: AppOptions): IApp {
   const container = new Container({ defaultScope: 'Singleton' });
   container.load(buildProviderModule());
-  const appService = container.get<IAppService>(IAppServiceKey);
-  return appService.registerApp(options);
+  const appController = container.get<IAppController>(IAppControllerKey);
+  return appController.registerApp(options);
 }
 
 function getAppWithLoadOptions(options: AppOptions, hooks: AppHooks = {}): IApp {

--- a/packages/core/src/application/app-controller/service.ts
+++ b/packages/core/src/application/app-controller/service.ts
@@ -1,0 +1,29 @@
+import { inject } from 'inversify';
+
+import { IRouterKey, IRouter } from '../../navigation/router/service';
+import { provide } from '../../provider';
+import { IAppService, IAppServiceKey } from '../app-service/service';
+import { IApp, AppOptions } from '../app/service';
+import { IAppController, IAppControllerKey } from './interface';
+
+export * from './interface';
+
+@provide(IAppControllerKey)
+export class AppController implements IAppController {
+  protected readonly _router: IRouter;
+
+  protected readonly _appService: IAppService;
+
+  constructor(@inject(IRouterKey) router: IRouter, @inject(IAppServiceKey) appService: IAppService) {
+    this._router = router;
+    this._appService = appService;
+  }
+
+  public registerApp(options: AppOptions): IApp {
+    return this._appService.registerApp(options, this._router);
+  }
+
+  public getApp(name: string): IApp {
+    return this._appService.getApp(name);
+  }
+}

--- a/packages/core/src/application/app-service/interface.ts
+++ b/packages/core/src/application/app-service/interface.ts
@@ -1,10 +1,11 @@
+import { IRouter } from '../../navigation/router/service';
 import { createServiceSymbol } from '../../utils';
 import { AppOptions, IApp } from '../app/service';
 
 export const IAppServiceKey = createServiceSymbol('IAppService');
 
 export interface IAppService {
-  registerApp: (options: AppOptions) => IApp;
+  registerApp: (options: AppOptions, router: IRouter) => IApp;
 
   getApp: (name: string) => IApp;
 }

--- a/packages/core/src/application/app-service/service.ts
+++ b/packages/core/src/application/app-service/service.ts
@@ -3,7 +3,7 @@ import { VerseaError } from '@versea/shared';
 import { inject, interfaces } from 'inversify';
 
 import { IStatusEnum, IStatusEnumKey } from '../../constants/status';
-import { IRouterKey, IRouter } from '../../navigation/router/service';
+import { IRouter } from '../../navigation/router/service';
 import { provide } from '../../provider';
 import { IApp, IAppKey, AppOptions } from '../app/service';
 import { IAppService, IAppServiceKey } from './interface';
@@ -16,21 +16,14 @@ export class AppService implements IAppService {
 
   protected readonly _AppConstructor: interfaces.Newable<IApp>;
 
-  protected readonly _router: IRouter;
-
   protected readonly _StatusEnum: IStatusEnum;
 
-  constructor(
-    @inject(IAppKey) App: interfaces.Newable<IApp>,
-    @inject(IRouterKey) router: IRouter,
-    @inject(IStatusEnumKey) StatusEnum: IStatusEnum,
-  ) {
+  constructor(@inject(IAppKey) App: interfaces.Newable<IApp>, @inject(IStatusEnumKey) StatusEnum: IStatusEnum) {
     this._AppConstructor = App;
-    this._router = router;
     this._StatusEnum = StatusEnum;
   }
 
-  public registerApp(options: AppOptions): IApp {
+  public registerApp(options: AppOptions, router: IRouter): IApp {
     if (this.appMap.has(options.name)) {
       throw new VerseaError(`Duplicate app name: "${options.name}".`);
     }
@@ -41,7 +34,7 @@ export class AppService implements IAppService {
 
     // 创建 routes
     if (options.routes?.length) {
-      this._router.addRoutes(options.routes, app);
+      router.addRoutes(options.routes, app);
     }
 
     return app;

--- a/packages/core/src/constants/status.ts
+++ b/packages/core/src/constants/status.ts
@@ -17,6 +17,10 @@ export const StatusEnum = {
   SkipBecauseBroken: 'SkipBecauseBroken',
 } as const;
 
-export type IStatusEnum = typeof StatusEnum;
+type IStatusEnumTyped = typeof StatusEnum;
+
+// 将 IStatusEnum 转换成 interface 导出，方便外部合并类型
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface IStatusEnum extends IStatusEnumTyped {}
 
 provideValue(StatusEnum, IStatusEnumKey);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './application/app/service';
+export * from './application/app-controller/service';
 export * from './application/app-service/service';
 export * from './constants/container-module';
 export * from './constants/status';

--- a/packages/core/src/navigation/matcher/interface.ts
+++ b/packages/core/src/navigation/matcher/interface.ts
@@ -1,4 +1,4 @@
-import { IApp } from '../../application/app/interface';
+import { IApp } from '../../application/app/service';
 import { createServiceSymbol } from '../../utils';
 import { IRoute, MatchedRoute, RouteOptions } from '../route/service';
 

--- a/packages/core/src/navigation/router/interface.ts
+++ b/packages/core/src/navigation/router/interface.ts
@@ -1,4 +1,4 @@
-import { IApp } from '../../application/app/interface';
+import { IApp } from '../../application/app/service';
 import { createServiceSymbol } from '../../utils';
 import { RouteOptions } from '../route/service';
 

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,8 +1,8 @@
 // export default 'hello world';
 import {
   buildProviderModule,
-  IAppService,
-  IAppServiceKey,
+  IAppController,
+  IAppControllerKey,
   App,
   AppOptions,
   IAppKey,
@@ -42,11 +42,11 @@ parent.rebind('TestData').toConstantValue('test2');
 
 // parent.rebind(IAppKey).toConstructor(NewApp);
 
-const app1 = parent.get<IAppService>(IAppServiceKey).registerApp({
+const app1 = parent.get<IAppController>(IAppControllerKey).registerApp({
   name: 'app1',
   path: 'app1_path',
 } as AppOptions);
-const app2 = parent.get<IAppService>(IAppServiceKey).registerApp({
+const app2 = parent.get<IAppController>(IAppControllerKey).registerApp({
   name: 'app2',
   path: 'app2_path',
   routes: [


### PR DESCRIPTION
由于存在依赖关系 IAppService -> IRouter -> IPerformance -> IAppService，循环引用会导致 inversify 执行失败。

增加 IAppController，使依赖关系变成 IAppController -> IRouter -> IPerformance 、 IPerformance -> IAppService 和 IAppController -> IAppService