### PR TITLE
refactor(core): refactor container

### DIFF
--- a/packages/core/src/app-switcher/renderer/service.ts
+++ b/packages/core/src/app-switcher/renderer/service.ts
@@ -248,17 +248,18 @@ export class Renderer implements IRenderer {
     }
   }
 
+  // Container 的渲染需要读取 meta 的 container 函数，这块后面重构
   protected _findParentApps(toMountApps: IApp[], defaultApp: IApp): IApp[] {
     const result = toMountApps.map(() => defaultApp);
-    for (const currentRoute of this.currentRoutes) {
-      for (const app of currentRoute.apps) {
-        toMountApps.forEach((toMountApp, index) => {
-          if (app.hasChildContainerHook(toMountApp.name)) {
-            result[index] = app;
-          }
-        });
-      }
-    }
+    // for (const currentRoute of this.currentRoutes) {
+    //   for (const app of currentRoute.apps) {
+    //     toMountApps.forEach((toMountApp, index) => {
+    //       if (app.hasChildContainerHook(toMountApp.name)) {
+    //         result[index] = app;
+    //       }
+    //     });
+    //   }
+    // }
     return result;
   }
 

--- a/packages/core/src/application/app/interface.ts
+++ b/packages/core/src/application/app/interface.ts
@@ -62,15 +62,12 @@ export interface IApp {
   /** 获取最终传给加载和挂载的各个阶段函数的属性 */
   getProps: (context: IAppSwitcherContext) => AppProps;
 
-  /** 判断应用是否有等待容器渲染完成的 Hooks */
-  hasChildContainerHook: (name: string) => boolean;
-
   /**
    * 等待应用内部容器渲染完成
-   * @param name - 嵌套的应用的名称
+   * @param containerName - 能嵌套应用的容器的名称
    * @description 参考 issue https://github.com/versea/versea/issues/8。
    */
-  waitForChildContainer: (name: string, context: IAppSwitcherContext) => Promise<void>;
+  waitForChildContainer: (containerName: string, context: IAppSwitcherContext) => Promise<void>;
 }
 
 /** App 实例化的参数 */

--- a/packages/core/src/application/app/service.ts
+++ b/packages/core/src/application/app/service.ts
@@ -145,24 +145,20 @@ export class App extends ExtensibleEntity implements IApp {
   }
 
   @memoizePromise()
-  public async waitForChildContainer(name: string, context: IAppSwitcherContext): Promise<void> {
+  public async waitForChildContainer(containerName: string, context: IAppSwitcherContext): Promise<void> {
     if (this.status !== this._Status.Mounted) {
       throw new VerseaError(`Can not run waiting because app "${this.name}" status is "${this.status}".`);
     }
 
-    if (!this._waitForChildrenContainerHooks[name]) {
+    if (!this._waitForChildrenContainerHooks[containerName]) {
       if (process.env.NODE_ENV !== 'production') {
         console.warn(`Can not found waiting for function, it may cause mounting child app error.`);
       }
       return;
     }
 
-    await this._waitForChildrenContainerHooks[name](this.getProps(context));
+    await this._waitForChildrenContainerHooks[containerName](this.getProps(context));
     return;
-  }
-
-  public hasChildContainerHook(name: string): boolean {
-    return this.status === this._Status.Mounted && !!this._waitForChildrenContainerHooks[name];
   }
 
   public getProps(context: IAppSwitcherContext): AppProps {

--- a/packages/core/src/navigation/matcher/service.spec.ts
+++ b/packages/core/src/navigation/matcher/service.spec.ts
@@ -48,9 +48,12 @@ describe('Matcher', () => {
     test('先创建一个路径为 path1 的 route 节点，后创建一个路径为 path1 的 route 节点，Matcher.trees 应该能合并节点。', () => {
       const matcher = getMatcher();
       const app1 = getAppInstance('name1');
-      matcher.addRoutes([{ path: 'path1' }], app1);
+      matcher.addRoutes([{ path: 'path1', meta: { test: 'test' } }], app1);
       const app2 = getAppInstance('name2');
-      matcher.addRoutes([{ path: 'path1', isFragment: true }], app2);
+      matcher.addRoutes(
+        [{ path: 'path1', isFragment: true, meta: { parentAppName: 'name1', parentContainerName: 'container1' } }],
+        app2,
+      );
 
       expect((matcher as any)._trees).toMatchObject([
         {
@@ -63,6 +66,13 @@ describe('Matcher', () => {
               name: 'name2',
             },
           ],
+          meta: {
+            test: 'test',
+            name2: {
+              parentAppName: 'name1',
+              parentContainerName: 'container1',
+            },
+          },
         },
       ]);
     });
@@ -74,9 +84,15 @@ describe('Matcher', () => {
       const app2 = getAppInstance('name2');
       matcher.addRoutes([{ path: 'path2' }], app2);
       const app3 = getAppInstance('name3');
-      matcher.addRoutes([{ path: 'path2', isFragment: true }], app3);
+      matcher.addRoutes(
+        [{ path: 'path2', isFragment: true, meta: { parentAppName: 'name2', parentContainerName: 'container2' } }],
+        app3,
+      );
       const app4 = getAppInstance('name4');
-      matcher.addRoutes([{ path: 'path1', isFragment: true }], app4);
+      matcher.addRoutes(
+        [{ path: 'path1', isFragment: true, meta: { parentAppName: 'name1', parentContainerName: 'container1' } }],
+        app4,
+      );
       const app5 = getAppInstance('name5');
       matcher.addRoutes([{ path: 'path3' }], app5);
 
@@ -290,7 +306,17 @@ describe('Matcher', () => {
       const app2 = getAppInstance('name2');
       matcher.addRoutes([{ path: 'path2', fill: 'foo' }], app2);
       const app3 = getAppInstance('name3');
-      matcher.addRoutes([{ path: 'path2', fill: 'foo', isFragment: true }], app3);
+      matcher.addRoutes(
+        [
+          {
+            path: 'path2',
+            fill: 'foo',
+            isFragment: true,
+            meta: { parentAppName: 'name2', parentContainerName: 'container2' },
+          },
+        ],
+        app3,
+      );
 
       expect((matcher as any)._trees).toMatchObject([
         {
@@ -322,7 +348,17 @@ describe('Matcher', () => {
       const app1 = getAppInstance('name1');
       matcher.addRoutes([{ path: 'path1', slot: 'foo' }], app1);
       const app2 = getAppInstance('name2');
-      matcher.addRoutes([{ path: 'path2', fill: 'foo', isFragment: true }], app2);
+      matcher.addRoutes(
+        [
+          {
+            path: 'path2',
+            fill: 'foo',
+            isFragment: true,
+            meta: { parentAppName: 'name1', parentContainerName: 'container1' },
+          },
+        ],
+        app2,
+      );
       const app3 = getAppInstance('name3');
       matcher.addRoutes([{ path: 'path2', fill: 'foo', children: [{ path: 'path3' }] }], app3);
 

--- a/packages/core/src/navigation/route/interface.ts
+++ b/packages/core/src/navigation/route/interface.ts
@@ -32,10 +32,10 @@ export interface IRoute {
 
   children: IRoute[];
 
-  /** route 的 children 允许其他的应用的路由插入的名称 */
+  /** route 的 children 允许其他的应用的路由插入的名称, 同时也是容器名称 */
   slot?: string;
 
-  /** route 的整个内容需要插入其他的应用的路由作为 children 的名称 */
+  /** route 的整个内容需要插入其他的应用的路由作为 children 的名称，同时也是容器名称 */
   fill?: string;
 
   /** pathToRegexp 的参数 */
@@ -69,7 +69,7 @@ export interface RouteConfig {
   path: string;
 
   /** route 额外参数 */
-  meta?: Record<string, unknown>;
+  meta?: RouteMeta;
 
   /** 声明一个路由是否是一个碎片路由 */
   isFragment?: boolean;
@@ -79,14 +79,24 @@ export interface RouteConfig {
 
   children?: RouteConfig[];
 
-  /** route 的 children 允许其他的应用的路由插入的名称 */
+  /** route 的 children 允许其他的应用的路由插入的名称, 同时也是容器名称 */
   slot?: string;
 
-  /** route 的整个内容需要插入其他的应用的路由作为 children 的名称 */
+  /** route 的整个内容需要插入其他的应用的路由作为 children 的名称，同时也是容器名称 */
   fill?: string;
 
   /** pathToRegexp 的参数 */
   pathToRegexpOptions?: PathToRegexpOptions;
+}
+
+export interface RouteMeta {
+  [key: string]: unknown;
+
+  /** 嵌套的父应用名称 */
+  parentAppName?: string;
+
+  /** 嵌套的父应用容器名称 */
+  parentContainerName?: string;
 }
 
 export interface ToMatchedRouteOptions {
@@ -100,6 +110,9 @@ type MatchedRouteTyped = Omit<
   'children' | 'fill' | 'isFragment' | 'parent' | 'pathToRegexpOptions' | 'slot' | 'slotRoutes'
 > &
   ToMatchedRouteOptions & {
+    /** 嵌套的父应用容器名称 */
+    parentContainerName?: string;
+
     /** 获取 matchedRoute 原本的 route 对象 */
     getRoute: () => IRoute;
   };

--- a/packages/core/src/navigation/route/interface.ts
+++ b/packages/core/src/navigation/route/interface.ts
@@ -110,11 +110,9 @@ type MatchedRouteTyped = Omit<
   'children' | 'fill' | 'isFragment' | 'parent' | 'pathToRegexpOptions' | 'slot' | 'slotRoutes'
 > &
   ToMatchedRouteOptions & {
-    /** 嵌套的父应用容器名称 */
-    parentContainerName?: string;
-
     /** 获取 matchedRoute 原本的 route 对象 */
     getRoute: () => IRoute;
+    clone: () => MatchedRoute;
   };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/packages/core/src/navigation/route/service.ts
+++ b/packages/core/src/navigation/route/service.ts
@@ -152,11 +152,11 @@ export class Route extends ExtensibleEntity implements IRoute {
       ...extensibleObject,
       path: this.path,
       apps: this.apps,
-      meta: clone(this.meta),
-      parentContainerName: this.fill,
+      meta: { parentContainerName: this.fill, ...clone(this.meta) },
       fullPath: this.fullPath,
       params: options.params ?? {},
       query: options.query ?? {},
+      clone: (): MatchedRoute => this.toMatchedRoute(options),
       getRoute: (): IRoute => this,
     };
   }


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [ ] Fork the repo and create your branch from `main`.
- [ ] If you've added code that should be tested, add tests!
- [ ] Ensure the test suite passes (`yarn test`).
- [ ] Make sure your code lints (`yarn lint`).

**Please do not delete the above content**

---

## What have you changed?

重构嵌套路由和嵌套应用时容器加载（假设 A(nameA) 嵌套 B(nameB)）

之前的逻辑：
1. A 需要在 mount 方法返回 { nameB: () => promise }
2. B 应用 mount 时循环已经 mounted 的应用，找到 A 应用上 存储的 nameB，调用 nameB 对应的方法

这里存在明显的逻辑问题，对于A 应用的开发者，他根据不关心嵌套的是 B 应用还是 C 应用或其他应用，因此让他在 mount 方法返回一个 nameB 的函数是不合理的

改过之后的逻辑：

对于 A 嵌套 B 的情况，A 应用的开发者不关心嵌套的是 B 应用还是 C 应用，他更关心一个问题就是他嵌套的这个容器的的名称

```js
// main.js
export function mount() {
  return {
    containerA: () => {
      // return  containerA 的 div 渲染完成的promise
    }
  }
}

// 可以嵌套的容器的dom 节点，vue 为例子
<template>
  <div>组件自己的内容</div>
  <div id="containerA"></div>
</template>
<script>
// ...
<script>
```

对于 B 应用的开发者来说，他是需要关心B应用嵌套在哪里，也就是 parentApp 是谁，也需要关心 container 名称是什么，他才知道需要渲染在那个 dom 节点，因此改动之后如下：

1. A 需要在 mount 方法返回 { [containerName]: () => promise }
2. B 应用 mount 时根据 meta 信息的 parentAppName 和 parentContainerName，调用 [containerName] 对应的方法

